### PR TITLE
Add user agent headers to request to avoid 403

### DIFF
--- a/higdon.py
+++ b/higdon.py
@@ -23,7 +23,10 @@ def get_higdon_plan(url):
     and return in as a daily sequence.
 
     """
-    resp = requests.get(url)
+    headers = {
+        "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/110.0.0.0 Safari/537.36"
+    }
+    resp = requests.get(url, headers=headers)
     soup = bs4.BeautifulSoup(resp.text, features="html.parser")
 
     def gen_week(row):


### PR DESCRIPTION
Resolves 403 Forbidden response I was experiencing when trying to hit the higdon webpage. 

Many websites block requests that don't include a User-Agent in the headers, assuming they are from bots. This change mimics browers user-agent to overcome this protection. Higdon's site must've added this protection since last changes to this repo. Thanks!
